### PR TITLE
Unreachable code detected.

### DIFF
--- a/SharpJson.cs
+++ b/SharpJson.cs
@@ -410,7 +410,6 @@ namespace SharpJson
 				}
 			}
 			
-			return null;
 		}
 
 		IList<object> ParseArray()
@@ -444,7 +443,6 @@ namespace SharpJson
 				}
 			}
 			
-			return null;
 		}
 
 		object ParseValue()


### PR DESCRIPTION
MonoDevelop, Visual Studio, and Unity's Mono compiler all detect these (lines 413 and 447) as unreachable code. Keeps logging warnings when compiling.
